### PR TITLE
Initial build for file feedstock

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 {% set version = "5.39" %}
 
 package:
-  name: {{ name|lower }}
+  name: file-split
   version: {{ version }}
 
 source:
@@ -51,7 +51,9 @@ outputs:
         - {{ compiler('c') }}
         - make
       host:
-        - zlib  # [unix]
+        # Not needed since no build will happen, but it stop conda-build from complaining
+        # that libmagic doesn't exist during the DSO analysis.
+        - {{ pin_subpackage("libmagic", exact=True) }}
       run:
         - {{ pin_subpackage("libmagic", exact=True) }}
     files:
@@ -75,11 +77,13 @@ outputs:
         requires a bit of I/O.
 
 about:
-  home: http://darwinsys.com/file
+  home: https://darwinsys.com/file/
   summary: Fine Free File Command
   license: BSD-2-Clause
+  license_family: BSD
   license_file: COPYING
   dev_url: https://github.com/file/file
+  doc_url: https://darwinsys.com/file/
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
file+libmagic 5.39

**Destination channel:** defaults

### Links

- [PKG-4029](https://anaconda.atlassian.net/browse/PKG-4029)
- [Upstream repository](https://github.com/file/file/tree/FILE5_39)

### Explanation of changes:

Our current `libmagic` lives in https://github.com/AnacondaRecipes/libmagic-feedstock. conda-forge archived their repo and moved it to https://github.com/conda-forge/file-feedstock.

This PR does exactly this.

We needed to build libmagic 5.39 on all platforms (for consistency).

Things to review are the feedstock, and the build number. Since we already have 5.39 on defaults, it's important that we don't override it by mistake.


[PKG-4029]: https://anaconda.atlassian.net/browse/PKG-4029?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ